### PR TITLE
feat: add locked flag to onPointerLock event.

### DIFF
--- a/posix.api.md
+++ b/posix.api.md
@@ -201,7 +201,9 @@ export interface IEvents {
     userId: string
   }
 
-  onPointerLock: {}
+  onPointerLock: {
+    locked?: boolean
+  }
 
   // (undocumented)
   onTextSubmit: {
@@ -261,6 +263,7 @@ export interface IEvents {
     currentOffset: number
     totalVideoLength: number
   }
+
 }
 
 // @public (undocumented)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -348,7 +348,9 @@ export interface IEvents {
    * `onPointerLock` is triggered when the user clicks the world canvas and the
    * pointer locks to it so the pointer moves the camera
    */
-  onPointerLock: {}
+  onPointerLock: {
+    locked?: boolean
+  }
 
   /**
    * `onAnimationEnd` is triggered when an animation clip gets finish
@@ -498,4 +500,5 @@ export interface IEvents {
     ethAddress: string
     version: number
   }
+
 }


### PR DESCRIPTION
This event wasn't being triggered and it's neccesary the locked state to know if the user is moving the cursor or the camera.

See more https://github.com/decentraland/sdk/issues/113