### PR TITLE
chore: rename player connected/disconnected events

### DIFF
--- a/posix.api.md
+++ b/posix.api.md
@@ -112,14 +112,6 @@ export type IEventNames = keyof IEvents
 export interface IEvents {
   actionButtonEvent: GlobalInputEventResult
 
-  avatarConnected: {
-    userId: string
-  }
-
-  avatarDisconnected: {
-    userId: string
-  }
-
   builderSceneStart: {}
 
   builderSceneUnloaded: {}
@@ -216,6 +208,14 @@ export interface IEvents {
   // (undocumented)
   onTextSubmit: {
     text: string
+  }
+
+  playerConnected: {
+    userId: string
+  }
+
+  playerDisconnected: {
+    userId: string
   }
 
   // (undocumented)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -502,12 +502,12 @@ export interface IEvents {
   }
 
   /** Triggered when peer's avatar is connected and visible */
-  avatarConnected: {
+  playerConnected: {
     userId: string
   }
 
   /** Triggered when peer disconnect and/or it avatar is set invisible by comms */
-  avatarDisconnected: {
+  playerDisconnected: {
     userId: string
   }
 }


### PR DESCRIPTION
*renamed `avatarConnected` to `playerConnected`
*renamed `avatarDisconnected` to `playerDisconnected`